### PR TITLE
Implement image download and currents API

### DIFF
--- a/dist/copernicus/copernicus.js
+++ b/dist/copernicus/copernicus.js
@@ -1,7 +1,62 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.fetchCurrents = fetchCurrents;
+const http = __importStar(require("http"));
+const https = __importStar(require("https"));
 async function fetchCurrents(config) {
-    // TODO: Реализовать подключение к Copernicus API
-    return { currents: 'Placeholder data' };
+    return new Promise((resolve, reject) => {
+        const lib = config.url.startsWith('https') ? https : http;
+        lib
+            .get(config.url, (res) => {
+            if (res.statusCode !== 200) {
+                reject(new Error(`Failed to fetch currents: ${res.statusCode}`));
+                res.resume();
+                return;
+            }
+            let data = '';
+            res.on('data', (chunk) => (data += chunk));
+            res.on('end', () => {
+                try {
+                    resolve(JSON.parse(data));
+                }
+                catch (e) {
+                    reject(e);
+                }
+            });
+        })
+            .on('error', reject);
+    });
 }

--- a/dist/imagery/imagery.js
+++ b/dist/imagery/imagery.js
@@ -1,7 +1,70 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.downloadImages = downloadImages;
+const promises_1 = require("fs/promises");
+const path_1 = require("path");
+const http = __importStar(require("http"));
+const https = __importStar(require("https"));
 async function downloadImages(config) {
-    // TODO: Реализовать загрузку изображений
-    console.log('Images downloaded');
+    const outputDir = config.outputDir || 'images';
+    await (0, promises_1.mkdir)(outputDir, { recursive: true });
+    await Promise.all(config.urls.map((url) => {
+        const lib = url.startsWith('https') ? https : http;
+        return new Promise((resolve, reject) => {
+            lib
+                .get(url, (res) => {
+                if (res.statusCode !== 200) {
+                    reject(new Error(`Failed to download ${url}: ${res.statusCode}`));
+                    res.resume();
+                    return;
+                }
+                const chunks = [];
+                res.on('data', (c) => chunks.push(c));
+                res.on('end', async () => {
+                    try {
+                        const filePath = (0, path_1.join)(outputDir, (0, path_1.basename)(url));
+                        await (0, promises_1.writeFile)(filePath, Buffer.concat(chunks));
+                        resolve();
+                    }
+                    catch (e) {
+                        reject(e);
+                    }
+                });
+            })
+                .on('error', reject);
+        });
+    }));
 }

--- a/src/copernicus/copernicus.ts
+++ b/src/copernicus/copernicus.ts
@@ -1,4 +1,33 @@
-export async function fetchCurrents(config: any): Promise<any> {
-  // TODO: Реализовать подключение к Copernicus API
-  return { currents: 'Placeholder data' };
+import * as http from 'http';
+import * as https from 'https';
+
+export interface CurrentsConfig {
+  url: string;
+}
+
+export async function fetchCurrents(config: CurrentsConfig): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const lib = config.url.startsWith('https') ? https : http;
+    lib
+      .get(config.url, (res) => {
+        if (res.statusCode !== 200) {
+          reject(
+            new Error(`Failed to fetch currents: ${res.statusCode}`)
+          );
+          res.resume();
+          return;
+        }
+
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(data));
+          } catch (e) {
+            reject(e);
+          }
+        });
+      })
+      .on('error', reject);
+  });
 }

--- a/src/imagery/imagery.ts
+++ b/src/imagery/imagery.ts
@@ -1,4 +1,45 @@
-export async function downloadImages(config: any): Promise<void> {
-  // TODO: Реализовать загрузку изображений
-  console.log('Images downloaded');
+import { mkdir, writeFile } from 'fs/promises';
+import { basename, join } from 'path';
+import * as http from 'http';
+import * as https from 'https';
+
+export interface DownloadConfig {
+  urls: string[];
+  outputDir?: string;
+}
+
+export async function downloadImages(config: DownloadConfig): Promise<void> {
+  const outputDir = config.outputDir || 'images';
+  await mkdir(outputDir, { recursive: true });
+
+  await Promise.all(
+    config.urls.map((url) => {
+      const lib = url.startsWith('https') ? https : http;
+      return new Promise<void>((resolve, reject) => {
+        lib
+          .get(url, (res) => {
+            if (res.statusCode !== 200) {
+              reject(
+                new Error(`Failed to download ${url}: ${res.statusCode}`)
+              );
+              res.resume();
+              return;
+            }
+
+            const chunks: Buffer[] = [];
+            res.on('data', (c) => chunks.push(c));
+            res.on('end', async () => {
+              try {
+                const filePath = join(outputDir, basename(url));
+                await writeFile(filePath, Buffer.concat(chunks));
+                resolve();
+              } catch (e) {
+                reject(e);
+              }
+            });
+          })
+          .on('error', reject);
+      });
+    })
+  );
 }

--- a/tests/imagery_copernicus.test.ts
+++ b/tests/imagery_copernicus.test.ts
@@ -1,0 +1,39 @@
+import { downloadImages } from '../src/imagery/imagery';
+import { fetchCurrents } from '../src/copernicus/copernicus';
+import * as fs from 'fs/promises';
+import * as http from 'http';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('downloadImages', () => {
+  test('downloads a file from a URL', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('image-data');
+    });
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+    const port = (server.address() as any).port;
+    const url = `http://localhost:${port}/image.txt`;
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'img-'));
+    await downloadImages({ urls: [url], outputDir: tmpDir });
+    const content = await fs.readFile(path.join(tmpDir, 'image.txt'), 'utf-8');
+    expect(content).toBe('image-data');
+    server.close();
+  });
+});
+
+describe('fetchCurrents', () => {
+  test('fetches JSON data from a URL', async () => {
+    const data = { currents: 'ok' };
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    });
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+    const port = (server.address() as any).port;
+    const url = `http://localhost:${port}/currents`;
+    const result = await fetchCurrents({ url });
+    expect(result).toEqual(data);
+    server.close();
+  });
+});


### PR DESCRIPTION
## Summary
- implement basic `downloadImages` to fetch HTTP/HTTPS content to files
- implement `fetchCurrents` to retrieve JSON data from a URL
- add Jest tests verifying both new functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885416dd098833092bbdc4758354684